### PR TITLE
add libXinerama-devel to fedora package list

### DIFF
--- a/_develop/compiling.md
+++ b/_develop/compiling.md
@@ -49,7 +49,7 @@ By default Fyne uses the [gl](https://github.com/go-gl/gl) and [GLFW](https://gi
 | Distribution  | Packages required                |
 |---------------|----------------------------------|
 | Debian/Ubuntu | `libgl1-mesa-dev` and `xorg-dev` |
-| Fedora        |  ``libXcursor-devel``  ``libXrandr-devel``  ``mesa-libGL-devel``  ``libXi-devel``|
+| Fedora        |  ``libXcursor-devel``  ``libXrandr-devel``  ``mesa-libGL-devel``  ``libXi-devel`` ``libXinerama-devel``|
 
 </div>
 


### PR DESCRIPTION
required or else:

```
fyne.io/fyne/theme
# fyne.io/fyne/vendor/github.com/go-gl/glfw/v3.2/glfw
In file included from ./glfw/src/internal.h:169,
                 from ./glfw/src/context.c:28,
                 from ../../vendor/github.com/go-gl/glfw/v3.2/glfw/c_glfw.go:4:
./glfw/src/x11_platform.h:48:10: fatal error: X11/extensions/Xinerama.h: No such file or directory
   48 | #include <X11/extensions/Xinerama.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```