### PR TITLE
Update links to https versions over http

### DIFF
--- a/_develop/cross-compiling.md
+++ b/_develop/cross-compiling.md
@@ -24,7 +24,7 @@ There are many ways to install the required tools - and different tools that can
 |------|----|----------|----------|-------|
 | `darwin`  | `o32-clang` | osxcross | [from github.com](https://github.com/tpoechtrager/osxcross) | You will also need to install the macOS SDK (instructions at the download link) |
 | `windows` | `x86_64-w64-mingw32-gcc` | mingw64 | package manager | For macOS use [homebrew](https://brew.sh) |
-| `linux`   | `gcc` or `x86_64-linux-musl-gcc` | gcc or musl-cross | [cygwin](http://www.cygwin.com/) or package manager | musl-cross is available from [homebrew](https://brew.sh) to provide the linux gcc. You will also need to install X11 and mesa headers for compilation. |
+| `linux`   | `gcc` or `x86_64-linux-musl-gcc` | gcc or musl-cross | [cygwin](https://www.cygwin.com/) or package manager | musl-cross is available from [homebrew](https://brew.sh) to provide the linux gcc. You will also need to install X11 and mesa headers for compilation. |
 
 With the environment variables above set you should be able to compile in the usual manner.
 If further errors occur it is likely to be due to missing packages. Some target platforms require additional libraries or headers to be installed for the compilation to succeed.

--- a/_develop/index.md
+++ b/_develop/index.md
@@ -55,7 +55,7 @@ Note that these steps are just required for development - your Fyne applications
 1. Download Go from the [download page](https://golang.org/dl/) and follow instructions
 2. Install one of the available C compilers for windows, the following are tested with Go and Fyne:
     * MSYS2 with MingW-w64 - [msys2.org](https://www.msys2.org/)
-    * TDM-GCC - [tdm-gcc.tdragon.net](http://tdm-gcc.tdragon.net/download)
+    * TDM-GCC - [tdm-gcc.tdragon.net](https://jmeubank.github.io/tdm-gcc/download/)
     * Cygwin - [cygwin.com](https://www.cygwin.com/)
 3. In Windows your graphics driver will already be installed, but it is recommended to ensure they are up to date.
 

--- a/_posts/2018-02-17-first-10-days-of-fyne.md
+++ b/_posts/2018-02-17-first-10-days-of-fyne.md
@@ -6,9 +6,9 @@ categories: blog
 ---
 
 It's been just 10 days since the Fyne project was announced and in that time we've had a lot of support! The IRC channel, which we added only a week ago, now has a core group of developers helping to discuss and guide the design of the toolkit.
-The [website](http://fyne.io) is up and running to help visitors understand what the project is about and see our progress. For the more developer oriented there is now a [walking skeleton](https://github.com/fyne-io/fyne/projects/1) project which is tracking progress towards our first milestone.
+The [website](https://fyne.io) is up and running to help visitors understand what the project is about and see our progress. For the more developer oriented there is now a [walking skeleton](https://github.com/fyne-io/fyne/projects/1) project which is tracking progress towards our first milestone.
 
-In terms of a quick summary we have picked [Go](https://golang.org) as the main language for development and API. The rendering pipeline we are using is [EFL](http://enlightenment.org/), though the details will be hidden completely from the Fyne APIs. Lastly we [decided](https://github.com/fyne-io/fyne/wiki/Layout-Algorithm) on the use of the [Cassowary](http://overconstrained.io/) algorithm for layout - giving an experience similar to the iOS AutoLayout.
+In terms of a quick summary we have picked [Go](https://golang.org) as the main language for development and API. The rendering pipeline we are using is [EFL](https://www.enlightenment.org/), though the details will be hidden completely from the Fyne APIs. Lastly we [decided](https://github.com/fyne-io/fyne/wiki/Layout-Algorithm) on the use of the [Cassowary](http://overconstrained.io/) algorithm for layout - giving an experience similar to the iOS AutoLayout.
 
 The Enlightenment IDE (Edi) has been updated for Go syntax and build lifecycle so anyone already working on EFL apps can continue using the same tooling for now :).
 

--- a/_posts/2018-06-26-fun-with-fractals.md
+++ b/_posts/2018-06-26-fun-with-fractals.md
@@ -63,7 +63,7 @@ many factors) that then updates the user interface. The relevant code is:
     }
 
     func main() {
-    	url := "http://fyne.io/feed.xml"
+    	url := "https://fyne.io/feed.xml"
 
     	// ...	
 

--- a/_posts/2019-03-19-building-cross-platform-gui.md
+++ b/_posts/2019-03-19-building-cross-platform-gui.md
@@ -5,7 +5,7 @@ date:   2019-03-19 11:53:12 +0000
 categories: blog
 ---
 
-There are many tutorials available online for how to use web technologies and [Go](https://golang.org) - but what if you want to create something in pure Go? Whether it's for performance reasons, to keep all of your application in just one programming language or simply because you like Go over Javascript and HTML there are solutions available. Go bindings exist for [GTK+](http://mattn.github.io/go-gtk/), [Qt](https://github.com/therecipe/qt), [Windows](https://github.com/lxn/walk), [Nuklear](https://github.com/golang-ui/nuklear) and also platform abstraction bindings like [andlabs UI](https://github.com/andlabs/ui).
+There are many tutorials available online for how to use web technologies and [Go](https://golang.org) - but what if you want to create something in pure Go? Whether it's for performance reasons, to keep all of your application in just one programming language or simply because you like Go over Javascript and HTML there are solutions available. Go bindings exist for [GTK+](https://mattn.github.io/go-gtk/), [Qt](https://github.com/therecipe/qt), [Windows](https://github.com/lxn/walk), [Nuklear](https://github.com/golang-ui/nuklear) and also platform abstraction bindings like [andlabs UI](https://github.com/andlabs/ui).
 
 In this tutorial we look at a newer approach - building a graphical application using a toolkit built specifically for go using a modern interpretation of the desktop user interface. The [Fyne](https://fyne.io) toolkit is a simple to learn graphical toolkit that we can use to build cross platform applications that will compile for macOS, Windows and Linux from the same code. We will explore how to get set up, write a basic application and then package it for distribution. Let's get started!
 
@@ -21,7 +21,7 @@ On macOS the XCode package provides this, but you will need to install the comma
 
 ### Windows
 
-Various compiler packages are available on Windows. Any of [Cygwin](https://www.cygwin.com/), [MSYS2](https://www.msys2.org/) and [TDM-GCC](http://tdm-gcc.tdragon.net/download) should work. MSYS2 is usually the easiest to install - download the package and run it. Remember that to compile Fyne applications you will need to use the MSYS2 command prompt rather than the standard windows `cmd` or PowerShell.
+Various compiler packages are available on Windows. Any of [Cygwin](https://www.cygwin.com/), [MSYS2](https://www.msys2.org/) and [TDM-GCC](https://jmeubank.github.io/tdm-gcc/download/) should work. MSYS2 is usually the easiest to install - download the package and run it. Remember that to compile Fyne applications you will need to use the MSYS2 command prompt rather than the standard windows `cmd` or PowerShell.
 
 ### Linux
 


### PR DESCRIPTION
This basically moves some older http links to https. It is good practice and if any of the websites are set up incorrectly, the user might not be redirected to the https site.