### PR TITLE
add a dockerized build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ This repository contains the source of the main https://fyne.io website.
 
 The website uses [jekyll](https://jekyllrb.com/) to generate the website from markdown files.
 With ruby installed it is as easy as running the following commands in a terminal (the first only needs to run once):
+
 ```bash
 gem install bundler jekyll
 bundle exec jekyll serve
 ```
+
+Alternatively, you can use the Dockerized build via either of:
+
+* `sh ./build.sh build` -- non-interactively build `./_site`
+* `sh ./build.sh serve` -- run `jekyll serve` inside of the docker container

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+set -u
+
+# Either run Jekyll interactively, or build the site statically, using a Docker
+# container.
+#
+# This is based on the official Jekyll Docker images:
+#
+# https://github.com/envygeeks/jekyll-docker/blob/master/README.md
+
+USAGE="sh ./build.sh [serve|build]" 
+
+if [ $# -ne 1 ] ; then
+	echo "$USAGE" 1>&2
+	exit 1
+fi
+
+cd "$(dirname "$0")"
+export JEKYLL_VERSION=3.8
+
+if [ "$1" = "serve" ] ; then
+	docker run --rm \
+		-p 4000:4000 \
+		--volume="$PWD:/srv/jekyll" \
+		-it jekyll/jekyll:$JEKYLL_VERSION \
+		jekyll serve
+elif [ "$1" = "build" ] ; then
+	docker run --rm \
+		--volume="$PWD:/srv/jekyll" \
+		-it jekyll/jekyll:$JEKYLL_VERSION \
+		jekyll build
+else
+	echo "$USAGE" 1>&2
+	exit 1
+fi
+


### PR DESCRIPTION
I always have dependency problems when using Ruby based tools such as
Jekyll. This would have saved me a lot of time, and maybe it will save
others time in the future.