### PR TITLE
It's -> its

### DIFF
--- a/fynedesk/index.md
+++ b/fynedesk/index.md
@@ -40,7 +40,7 @@ in the centre of how we work. Now you can have the desktop of your dreams
                 <h2 class="section-heading">Themes</h2>
                 <hr class="light">
                 <img src="https://github.com/fyne-io/fynedesk/raw/master/desktop-dark-current.png" alt="" />
-				<p class="caption light"><br />The standard theme in it's dark look.</p>
+				<p class="caption light"><br />The standard theme in its dark look.</p>
 				<p>&nbsp;</p>
                 <img src="https://github.com/fyne-io/fynedesk/raw/master/desktop-light-current.png" alt="" />
 				<p class="caption light"><br />The standard theme in light variant.</p>


### PR DESCRIPTION
HN no-likey.

https://news.ycombinator.com/item?id=28691156#28708628
 
> I hate to be that guy, but the first caption under the Themes section should read: "The standard theme in its dark look."
>
> Having the apostrophe in "its" makes it read "in it is dark look"