### PR TITLE
Fix Navigation from apps.fyne.io

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -25,16 +25,16 @@
 			<a href="https://apps.fyne.io/">Apps</a>
                 </li>
                 <li>
-                    <a href="https://addons.fyne.io/">Add-ons</a>
+                        <a href="https://addons.fyne.io/">Add-ons</a>
                 </li>
                 <li>
-			<a href="/blog/">Blog</a>
+			<a href="https://fyne.io/blog/">Blog</a>
                 </li>
                 <li>
-                    <a href="/events/">Events</a>
+                        <a href="https://fyne.io/events/">Events</a>
                 </li>
                 <li>
-                    <a href="/support/">Support</a>
+                        <a href="https://fyne.io/support/">Support</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Replaced relative URLs with absolute ones.
The relative links do not work when clicked while the user is at apps.fyne.io.