### PR TITLE
Convert links from http to https protocol

### DIFF
--- a/_posts/2018-02-17-first-10-days-of-fyne.md
+++ b/_posts/2018-02-17-first-10-days-of-fyne.md
@@ -8,7 +8,7 @@ categories: blog
 It's been just 10 days since the Fyne project was announced and in that time we've had a lot of support! The IRC channel, which we added only a week ago, now has a core group of developers helping to discuss and guide the design of the toolkit.
 The [website](https://fyne.io) is up and running to help visitors understand what the project is about and see our progress. For the more developer oriented there is now a [walking skeleton](https://github.com/fyne-io/fyne/projects/1) project which is tracking progress towards our first milestone.
 
-In terms of a quick summary we have picked [Go](https://golang.org) as the main language for development and API. The rendering pipeline we are using is [EFL](https://www.enlightenment.org/), though the details will be hidden completely from the Fyne APIs. Lastly we [decided](https://github.com/fyne-io/fyne/wiki/Layout-Algorithm) on the use of the [Cassowary](http://overconstrained.io/) algorithm for layout - giving an experience similar to the iOS AutoLayout.
+In terms of a quick summary we have picked [Go](https://golang.org) as the main language for development and API. The rendering pipeline we are using is [EFL](https://www.enlightenment.org/), though the details will be hidden completely from the Fyne APIs. Lastly we [decided](https://github.com/fyne-io/fyne/wiki/Layout-Algorithm) on the use of the [Cassowary](https://en.wikipedia.org/wiki/Cassowary_(software)) algorithm for layout - giving an experience similar to the iOS AutoLayout.
 
 The Enlightenment IDE (Edi) has been updated for Go syntax and build lifecycle so anyone already working on EFL apps can continue using the same tooling for now :).
 

--- a/_posts/2021-01-27-fyne-book-published.md
+++ b/_posts/2021-01-27-fyne-book-published.md
@@ -10,7 +10,7 @@ this week brings exciting news that the first book dedicated to Fyne has been pu
 
 <img src="/img/fyne-book-cover.jpg" style="max-width: 202px; float:right; padding-left: 5pt" />
 
-This book covers most aspects of building a Fyne app, including the [new APIs](http://developer.fyne.io/api/v2.0/)
+This book covers most aspects of building a Fyne app, including the [new APIs](https://docs.fyne.io/api/v2.0/)
 introduced in the recent release. It will step you through getting started with Fyne and
 how to build an app using the toolkit all the way through to uploading your software to 
 market places and App Stores.

--- a/_posts/2022-12-24-v2.3.md
+++ b/_posts/2022-12-24-v2.3.md
@@ -34,7 +34,7 @@ To see the complete list including bug fixes see the
 ### Added
 
 * Shiny new theme that was designed for us
-* Improved text handling to support non-latin alphabets
+* Improved text handling to support non-Latin alphabets
 * Add cloud storage and preference support
 * Add menu icon and submenu support to system tray menus
 * More button importance levels `ErrorImportance`, `WarningImportance`

--- a/_posts/2024-08-14-2.5.md
+++ b/_posts/2024-08-14-2.5.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Fyne v2.5 released with internationalistion and great new widgets"
+title:  "Fyne v2.5 released with internationalisation and great new widgets"
 date:   2024-08-14 13:15:00+1000
 categories: blog
 ---

--- a/cloud/index.html
+++ b/cloud/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/cloud git https://github.com/fyne-io/cloud">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/cloud">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/cloud">
     </head>
     <body>
-        The Fyne Cloud API - read the <a href="http://godoc.org/fyne.io/cloud">documentation</a>.
+        The Fyne Cloud API - read the <a href="https://pkg.go.dev/fyne.io/cloud">documentation</a>.
     </body>
 </html>

--- a/desktop/wm/index.html
+++ b/desktop/wm/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/desktop git https://github.com/fyne-io/fynedesk">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fynedesk">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fynedesk">
     </head>
     <body>
-        The Fyne Desktop - read the <a href="http://godoc.org/fyne.io/fynedesk">documentation</a>.
+        The Fyne Desktop - read the <a href="https://pkg.go.dev/fyne.io/fynedesk">documentation</a>.
     </body>
 </html>

--- a/fyne/app/index.html
+++ b/fyne/app/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/canvas/index.html
+++ b/fyne/canvas/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/cmd/fyne/index.html
+++ b/fyne/cmd/fyne/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/cmd/fyne_demo/index.html
+++ b/fyne/cmd/fyne_demo/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/cmd/fyne_settings/settings/index.html
+++ b/fyne/cmd/fyne_settings/settings/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/data/binding/index.html
+++ b/fyne/data/binding/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/data/index.html
+++ b/fyne/data/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/data/validation/index.html
+++ b/fyne/data/validation/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/dialog/index.html
+++ b/fyne/dialog/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/driver/desktop/index.html
+++ b/fyne/driver/desktop/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/driver/index.html
+++ b/fyne/driver/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/driver/mobile/index.html
+++ b/fyne/driver/mobile/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/index.html
+++ b/fyne/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/layout/index.html
+++ b/fyne/layout/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/test/index.html
+++ b/fyne/test/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/theme/index.html
+++ b/fyne/theme/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2.html
+++ b/fyne/v2.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/app/index.html
+++ b/fyne/v2/app/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/canvas/index.html
+++ b/fyne/v2/canvas/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/cmd/fyne/index.html
+++ b/fyne/v2/cmd/fyne/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/cmd/fyne_demo/index.html
+++ b/fyne/v2/cmd/fyne_demo/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/cmd/fyne_settings/index.html
+++ b/fyne/v2/cmd/fyne_settings/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/cmd/fyne_settings/settings/index.html
+++ b/fyne/v2/cmd/fyne_settings/settings/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/cmd/hello/index.html
+++ b/fyne/v2/cmd/hello/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/container/index.html
+++ b/fyne/v2/container/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/data/binding/index.html
+++ b/fyne/v2/data/binding/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/data/binding/v2.html
+++ b/fyne/v2/data/binding/v2.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/data/index.html
+++ b/fyne/v2/data/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/data/validation/index.html
+++ b/fyne/v2/data/validation/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/dialog/index.html
+++ b/fyne/v2/dialog/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/driver/desktop/index.html
+++ b/fyne/v2/driver/desktop/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/driver/index.html
+++ b/fyne/v2/driver/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/driver/mobile/index.html
+++ b/fyne/v2/driver/mobile/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/index.html
+++ b/fyne/v2/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/layout/index.html
+++ b/fyne/v2/layout/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/storage/index.html
+++ b/fyne/v2/storage/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/storage/repository/index.html
+++ b/fyne/v2/storage/repository/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/test/index.html
+++ b/fyne/v2/test/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/theme/index.html
+++ b/fyne/v2/theme/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/v2/widget/index.html
+++ b/fyne/v2/widget/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne/v2 git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/fyne/widget/index.html
+++ b/fyne/widget/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne">
     </head>
     <body>
-        The Fyne API - read the <a href="http://godoc.org/fyne.io/fyne">documentation</a>.
+        The Fyne API - read the <a href="https://pkg.go.dev/fyne.io/fyne">documentation</a>.
     </body>
 </html>

--- a/setup/index.html
+++ b/setup/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/setup git https://github.com/fyne-io/setup">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/setup">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/setup">
     </head>
     <body>
-        Assistance in Fyne development setup - <a href="http://github.com/fyne-io/setup">read more</a>.
+        Assistance in Fyne development setup - <a href="https://github.com/fyne-io/setup">read more</a>.
     </body>
 </html>

--- a/setup/pkg/index.html
+++ b/setup/pkg/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/setup git https://github.com/fyne-io/setup">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/setup">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/setup">
     </head>
     <body>
-        Assistance in Fyne development setup - <a href="http://github.com/fyne-io/setup">read more</a>.
+        Assistance in Fyne development setup - <a href="https://github.com/fyne-io/setup">read more</a>.
     </body>
 </html>

--- a/systray/example/index.html
+++ b/systray/example/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/systray git https://github.com/fyne-io/systray">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/systray">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/systray">
     </head>
     <body>
-        A Systray that works on any toolkit - <a href="http://github.com/fyne-io/systray">read more</a>.
+        A Systray that works on any toolkit - <a href="https://github.com/fyne-io/systray">read more</a>.
     </body>
 </html>

--- a/systray/index.html
+++ b/systray/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/systray git https://github.com/fyne-io/systray">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/systray">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/systray">
     </head>
     <body>
-        A Systray that works on any toolkit - <a href="http://github.com/fyne-io/systray">read more</a>.
+        A Systray that works on any toolkit - <a href="https://github.com/fyne-io/systray">read more</a>.
     </body>
 </html>

--- a/tools/index.html
+++ b/tools/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/tools git https://github.com/fyne-io/tools">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/tools">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/tools">
     </head>
     <body>
-        The Fyne Toolchain - read the <a href="http://developer.fyne.io">documentation</a>.
+        The Fyne Toolchain - read the <a href="https://docs.fyne.io/">documentation</a>.
     </body>
 </html>

--- a/x/fyne/data/binding/index.html
+++ b/x/fyne/data/binding/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/x/fyne git https://github.com/fyne-io/fyne-x">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne-x">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne-x">
     </head>
     <body>
-        The Fyne API extensions - read the <a href="http://godoc.org/fyne.io/fyne-x">documentation</a>.
+        The Fyne API extensions - read the <a href="https://pkg.go.dev/fyne.io/fyne-x">documentation</a>.
     </body>
 </html>

--- a/x/fyne/data/validation/index.html
+++ b/x/fyne/data/validation/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/x/fyne git https://github.com/fyne-io/fyne-x">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne-x">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne-x">
     </head>
     <body>
-        The Fyne API extensions - read the <a href="http://godoc.org/fyne.io/fyne-x">documentation</a>.
+        The Fyne API extensions - read the <a href="https://pkg.go.dev/fyne.io/fyne-x">documentation</a>.
     </body>
 </html>

--- a/x/fyne/index.html
+++ b/x/fyne/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/x/fyne git https://github.com/fyne-io/fyne-x">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne-x">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne-x">
     </head>
     <body>
-        The Fyne API extensions - read the <a href="http://godoc.org/fyne.io/fyne-x">documentation</a>.
+        The Fyne API extensions - read the <a href="https://pkg.go.dev/fyne.io/fyne-x">documentation</a>.
     </body>
 </html>

--- a/x/fyne/layout/index.html
+++ b/x/fyne/layout/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/x/fyne git https://github.com/fyne-io/fyne-x">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne-x">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne-x">
     </head>
     <body>
-        The Fyne API extensions - read the <a href="http://godoc.org/fyne.io/fyne-x">documentation</a>.
+        The Fyne API extensions - read the <a href="https://pkg.go.dev/fyne.io/fyne-x">documentation</a>.
     </body>
 </html>

--- a/x/fyne/widget/index.html
+++ b/x/fyne/widget/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/x/fyne git https://github.com/fyne-io/fyne-x">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne-x">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne-x">
     </head>
     <body>
-        The Fyne API extensions - read the <a href="http://godoc.org/fyne.io/fyne-x">documentation</a>.
+        The Fyne API extensions - read the <a href="https://pkg.go.dev/fyne.io/fyne-x">documentation</a>.
     </body>
 </html>

--- a/x/fyne/wrapper/index.html
+++ b/x/fyne/wrapper/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
         <meta name="go-import" content="fyne.io/x/fyne git https://github.com/fyne-io/fyne-x">
-        <meta http-equiv="refresh" content="0; url=http://github.com/fyne-io/fyne-x">
+        <meta http-equiv="refresh" content="0; url=https://github.com/fyne-io/fyne-x">
     </head>
     <body>
-        The Fyne API extensions - read the <a href="http://godoc.org/fyne.io/fyne-x">documentation</a>.
+        The Fyne API extensions - read the <a href="https://pkg.go.dev/fyne.io/fyne-x">documentation</a>.
     </body>
 </html>


### PR DESCRIPTION
This PR converts various links from `http` to `https` protocol.
It fixes a broken link in the first post of the project and two typos in other places, too.