### PR TITLE
Redirect toolkit bugs towards fyne-io/fyne

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+contact_links:
+  - name: Report bugs in the toolkit.
+    url: https://github.com/fyne-io/fyne/issues/new/choose
+    about: This repository only contains the fyne.io website. Use this link to instead open issues for the toolkit itself.
+
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,4 @@
+---
+name: Website Report
+about: Report issues or improvement suggestions about the fyne.io website content.
+---


### PR DESCRIPTION
Just adding some GitHub issue template infrastructure to hopefully decrease the amount of issues accidentally opened here instead of in the toolkit repository.